### PR TITLE
feat: add Gradle signing and publishing to Sonatype Nexus OSS

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -95,17 +95,19 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
       - name: Create a new release
         run: ./gradlew release
 
-      # TODO: provide OpenPGP signing keys
-      # using ORG_GRADLE_PROJECT_signingKey and ORG_GRADLE_PROJECT_signingPassword env vars
-      - name: Publish release
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: publish
+      - name: Publish with Gradle
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: $${{ secrets.PGP_SECRET }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+        run: ./gradlew publishToSonatype --no-daemon
 
   create-release:
      needs: [next-version, publish]

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -98,6 +98,8 @@ jobs:
       - name: Create a new release
         run: ./gradlew release
 
+      # TODO: provide OpenPGP signing keys
+      # using ORG_GRADLE_PROJECT_signingKey and ORG_GRADLE_PROJECT_signingPassword env vars
       - name: Publish release
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -95,10 +95,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Publish using Axion
+      - name: Create a new release
         run: ./gradlew release
 
-      - name: Publish package
+      - name: Publish release
         uses: gradle/gradle-build-action@v2
         with:
           arguments: publish

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Create a new release
         run: ./gradlew release
 
-      - name: Publish with Gradle
+      - name: Publish to Sonatype Nexus OSS
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 	jacoco
 	`maven-publish`
 	`java-library`
+	signing
 
 	id("pl.allegro.tech.build.axion-release") version "1.16.1"
 }
@@ -114,6 +115,17 @@ publishing {
 			}
 		}
 	}
+}
+
+signing {
+	// Signing requires an OpenPGP keypair and the ORG_GRADLE_PROJECT_signingKey
+	// and ORG_GRADLE_PROJECT_signingPassword environment variables to be provided (by GitHub in our case).
+	// See: https://docs.gradle.org/current/userguide/signing_plugin.html
+	val signingKey: String? by project
+	val signingPassword: String? by project
+	useInMemoryPgpKeys(signingKey, signingPassword)
+
+	sign(publishing.publications["mavenJava"])
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 	jacoco
 	`maven-publish`
 	`java-library`
-	signing
 
 	id("pl.allegro.tech.build.axion-release") version "1.16.1"
 }
@@ -115,10 +114,6 @@ publishing {
 			}
 		}
 	}
-}
-
-signing {
-	sign(publishing.publications["mavenJava"])
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 	signing
 
 	id("pl.allegro.tech.build.axion-release") version "1.16.1"
+	id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
 }
 
 repositories {
@@ -48,6 +49,16 @@ dependencies {
 java {
 	withJavadocJar()
 	withSourcesJar()
+}
+
+nexusPublishing {
+	repositories {
+		sonatype {
+			// only for users registered in Sonatype after 24 Feb 2021
+			nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+			snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+		}
+	}
 }
 
 publishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 	jacoco
 	`maven-publish`
 	`java-library`
+	signing
 
 	id("pl.allegro.tech.build.axion-release") version "1.16.1"
 }
@@ -114,6 +115,10 @@ publishing {
 			}
 		}
 	}
+}
+
+signing {
+	sign(publishing.publications["mavenJava"])
 }
 
 tasks {


### PR DESCRIPTION
Added Gradle signing and publishing to Sonatype Nexus OSS. Credentials are set using GitHub repository secrets.

Solves PZ-1060