### PR TITLE
chore: use Gradle version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,8 +12,8 @@ plugins {
 	`java-library`
 	signing
 
-	id("pl.allegro.tech.build.axion-release") version "1.16.1"
-	id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+	alias(libs.plugins.axion.release)
+	alias(libs.plugins.nexus.publish.plugin)
 }
 
 repositories {
@@ -29,21 +29,18 @@ java {
 	java.targetCompatibility = JavaVersion.VERSION_17
 }
 
-val junitVersion = "5.10.1"
-val jakartaServletVersion = "6.0.0"
-
 dependencies {
-	compileOnly("jakarta.servlet:jakarta.servlet-api:$jakartaServletVersion")
+	compileOnly(libs.jakarta.servlet.api)
 
-	implementation("org.slf4j:slf4j-api:2.0.11")
+	implementation(libs.slf4j.api)
 
-	testImplementation("jakarta.servlet:jakarta.servlet-api:$jakartaServletVersion")
-	testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-	testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-	testImplementation("org.jmock:jmock:2.12.0")
-	testImplementation("org.slf4j:slf4j-simple:2.0.11")
+	testImplementation(libs.jakarta.servlet.api)
+	testImplementation(libs.junit.jupiter.params)
+	testImplementation(libs.junit.jupiter.api)
+	testImplementation(libs.jmock)
+	testImplementation(libs.slf4j.simple)
 	
-	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+	testRuntimeOnly(libs.junit.jupiter.engine)
 }
 
 java {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,21 @@
+[versions]
+axion-release = "1.16.1"
+jakarta-servlet = "6.0.0"
+jmock = "2.12.0"
+junit = "5.10.1"
+nexus-publish-plugin = "1.3.0"
+slf4j = "2.0.11"
+
+[libraries]
+jakarta-servlet-api = { group = "jakarta.servlet", name = "jakarta.servlet-api", version.ref = "jakarta-servlet" }
+jmock = { group = "org.jmock", name = "jmock", version.ref = "jmock" }
+junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
+junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit" }
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j" }
+slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
+
+[plugins]
+axion-release = { id = "pl.allegro.tech.build.axion-release", version.ref = "axion-release" }
+nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus-publish-plugin" }
+


### PR DESCRIPTION
Refactored Gradle build file to use a Gradle version catalog for easier updating of shared dependencies, e.g. by Dependabot.

Solves PZ-1219