### PR TITLE
fix: add support for Gradle locks in GitHub pipeline 

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -40,7 +40,8 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: Gradle build with unit tests
-        run: ./gradlew build --info
+        # Use --write-locks to support dependency updates from Dependabot PRs
+        run: ./gradlew build --write-locks --info
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Added support for Gradle locks in GitHub pipeline for Dependabot PRs using the --write-locks option in the Gradle build.

Solves PZ-1270.