### PR TITLE
chore: set source & target JDK back to 17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,8 @@ dependencyLocking {
 }
 
 java {
-	java.sourceCompatibility = JavaVersion.VERSION_21
-	java.targetCompatibility = JavaVersion.VERSION_21
+	java.sourceCompatibility = JavaVersion.VERSION_17
+	java.targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {


### PR DESCRIPTION
Set source & target JDK back to 17 since ZAC is still on JDK 17 and currently cannot use webdav-servlet if the target compatibility is JDK 21.

Solves PZ-1488