### PR TITLE
fix: use the new GitHub secrets for the Nexus OSS Maven Central repo

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -122,8 +122,8 @@ jobs:
 
       - name: Publish to Sonatype Nexus OSS
         env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USER_TOKEN_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_USER_TOKEN_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
         run: ./gradlew publishToSonatype closeAndReleaseStagingRepository --no-daemon


### PR DESCRIPTION
Use the new GitHub secrets for the user token in the Nexus OSS Maven Central repo. Using username & password is no longer supported so we now use the user token username and password. See: https://central.sonatype.org/publish/generate-token/

Solves PZ-3268