### PR TITLE
chore: fix for code scanning alert "Resolving XML external entity in user-controlled data"

### DIFF
--- a/src/main/java/nl/info/webdav/methods/DoProppatch.java
+++ b/src/main/java/nl/info/webdav/methods/DoProppatch.java
@@ -3,7 +3,6 @@ package nl.info.webdav.methods;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Hashtable;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
 import java.util.logging.Logger;
@@ -34,9 +33,9 @@ import nl.info.webdav.locking.ResourceLocks;
 public class DoProppatch extends AbstractMethod {
     private static final Logger LOG = Logger.getLogger(DoProppatch.class.getName());
 
-    private boolean _readOnly;
-    private IWebdavStore _store;
-    private ResourceLocks _resourceLocks;
+    private final boolean _readOnly;
+    private final IWebdavStore _store;
+    private final ResourceLocks _resourceLocks;
 
     public DoProppatch(
             IWebdavStore store,
@@ -127,6 +126,9 @@ public class DoProppatch extends AbstractMethod {
                 if (req.getContentLength() != 0) {
                     try {
                         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                        // disable DTD's (external entities).
+                        // see: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
+                        // and: https://securecodingpractices.com/avoid-xxe-attacks-in-java-xml-parsers/
                         dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
                         dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
                         dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
@@ -194,10 +196,7 @@ public class DoProppatch extends AbstractMethod {
 
                 generatedXML.writeElement("DAV::href", XMLWriter.CLOSING);
 
-                for (Iterator<String> iter = tochange.iterator(); iter
-                        .hasNext();) {
-                    String property = iter.next();
-
+                for (String property : tochange) {
                     generatedXML.writeElement("DAV::propstat", XMLWriter.OPENING);
                     generatedXML.writeElement("DAV::prop", XMLWriter.OPENING);
                     generatedXML.writeElement(property, XMLWriter.NO_CONTENT);

--- a/src/main/java/nl/info/webdav/methods/DoProppatch.java
+++ b/src/main/java/nl/info/webdav/methods/DoProppatch.java
@@ -9,6 +9,7 @@ import java.util.Vector;
 import java.util.logging.Logger;
 
 import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -125,7 +126,14 @@ public class DoProppatch extends AbstractMethod {
 
                 if (req.getContentLength() != 0) {
                     try {
-                        DocumentBuilder documentBuilder = getDocumentBuilder();
+                        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                        dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                        dbf.setXIncludeAware(false);
+                        dbf.setExpandEntityReferences(false);
+                        DocumentBuilder documentBuilder = dbf.newDocumentBuilder();
                         Document document = documentBuilder
                                 .parse(new InputSource(req.getInputStream()));
                         // Get the root element of the document

--- a/src/test/java/nl/info/webdav/methods/DoProppatchTest.java
+++ b/src/test/java/nl/info/webdav/methods/DoProppatchTest.java
@@ -2,6 +2,7 @@ package nl.info.webdav.methods;
 
 import java.io.ByteArrayInputStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -110,6 +111,93 @@ public class DoProppatchTest extends MockTest {
 
                 oneOf(mockReq).getHeader("If");
                 will(returnValue(null));
+
+                oneOf(mockRes).sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR);
+            }
+        });
+
+        DoProppatch doProppatch = new DoProppatch(mockStore,
+                new ResourceLocks(), !readOnly);
+
+        doProppatch.execute(mockTransaction, mockReq, mockRes);
+
+        _mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void doProppatchWithXxeContentReturnsInternalServerError() throws Exception {
+
+        final String path = "/testFile";
+        final byte[] xxeContent = ("<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
+                + "<propertyupdate><set><prop><evil>&xxe;</evil></prop></set></propertyupdate>")
+                .getBytes(StandardCharsets.UTF_8);
+        final DelegatingServletInputStream xxeDsis = new DelegatingServletInputStream(
+                new ByteArrayInputStream(xxeContent));
+
+        _mockery.checking(new Expectations() {
+            {
+                exactly(2).of(mockReq).getAttribute("javax.servlet.include.request_uri");
+                will(returnValue(null));
+
+                exactly(2).of(mockReq).getPathInfo();
+                will(returnValue(path));
+
+                StoredObject testFileSo = initFileStoredObject(resourceContent);
+
+                oneOf(mockStore).getStoredObject(mockTransaction, path);
+                will(returnValue(testFileSo));
+
+                oneOf(mockReq).getHeader("If");
+                will(returnValue(null));
+
+                oneOf(mockReq).getContentLength();
+                will(returnValue(xxeContent.length));
+
+                oneOf(mockReq).getInputStream();
+                will(returnValue(xxeDsis));
+
+                oneOf(mockRes).sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR);
+            }
+        });
+
+        DoProppatch doProppatch = new DoProppatch(mockStore,
+                new ResourceLocks(), !readOnly);
+
+        doProppatch.execute(mockTransaction, mockReq, mockRes);
+
+        _mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void doProppatchWithMalformedXmlReturnsInternalServerError() throws Exception {
+
+        final String path = "/testFile";
+        final byte[] malformedContent = "not valid xml <<>>".getBytes(StandardCharsets.UTF_8);
+        final DelegatingServletInputStream malformedDsis = new DelegatingServletInputStream(
+                new ByteArrayInputStream(malformedContent));
+
+        _mockery.checking(new Expectations() {
+            {
+                exactly(2).of(mockReq).getAttribute("javax.servlet.include.request_uri");
+                will(returnValue(null));
+
+                exactly(2).of(mockReq).getPathInfo();
+                will(returnValue(path));
+
+                StoredObject testFileSo = initFileStoredObject(resourceContent);
+
+                oneOf(mockStore).getStoredObject(mockTransaction, path);
+                will(returnValue(testFileSo));
+
+                oneOf(mockReq).getHeader("If");
+                will(returnValue(null));
+
+                oneOf(mockReq).getContentLength();
+                will(returnValue(malformedContent.length));
+
+                oneOf(mockReq).getInputStream();
+                will(returnValue(malformedDsis));
 
                 oneOf(mockRes).sendError(WebdavStatus.SC_INTERNAL_SERVER_ERROR);
             }

--- a/src/test/java/nl/info/webdav/methods/DoProppatchTest.java
+++ b/src/test/java/nl/info/webdav/methods/DoProppatchTest.java
@@ -128,10 +128,9 @@ public class DoProppatchTest extends MockTest {
     public void doProppatchWithXxeContentReturnsInternalServerError() throws Exception {
 
         final String path = "/testFile";
-        final byte[] xxeContent = ("<?xml version=\"1.0\"?>"
-                + "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
-                + "<propertyupdate><set><prop><evil>&xxe;</evil></prop></set></propertyupdate>")
-                .getBytes(StandardCharsets.UTF_8);
+        final byte[] xxeContent = ("<?xml version=\"1.0\"?>" + "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>" +
+                                   "<propertyupdate><set><prop><evil>&xxe;</evil></prop></set></propertyupdate>")
+                                           .getBytes(StandardCharsets.UTF_8);
         final DelegatingServletInputStream xxeDsis = new DelegatingServletInputStream(
                 new ByteArrayInputStream(xxeContent));
 


### PR DESCRIPTION
Potential fix for [https://github.com/infonl/webdav-servlet/security/code-scanning/5](https://github.com/infonl/webdav-servlet/security/code-scanning/5)

Best fix: create and use a securely configured `DocumentBuilderFactory` in `DoProppatch` for this parse operation, explicitly disabling DTDs and external entity resolution before creating the `DocumentBuilder`.

In `src/main/java/nl/info/webdav/methods/DoProppatch.java`, update imports to include `javax.xml.parsers.DocumentBuilderFactory` and replace the `getDocumentBuilder()` usage in the `req.getContentLength() != 0` block with a locally hardened parser setup:

- `disallow-doctype-decl = true`
- `external-general-entities = false`
- `external-parameter-entities = false`
- `nonvalidating/load-external-dtd = false`
- `setXIncludeAware(false)`
- `setExpandEntityReferences(false)`

This preserves functionality for normal PROPPATCH XML bodies while preventing XXE vectors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

Solves PZ-11090
