### PR TITLE
Potential fix for code scanning alert no. 18: Cross-site scripting

### DIFF
--- a/src/main/java/nl/info/webdav/fromcatalina/XMLWriter.java
+++ b/src/main/java/nl/info/webdav/fromcatalina/XMLWriter.java
@@ -185,7 +185,11 @@ public class XMLWriter {
      *      Data to append
      */
     public void writeData(String data) {
-        _buffer.append("<![CDATA[").append(data).append("]]>");
+        String safeData = data == null ? "" : data;
+        // Prevent breaking out of CDATA by splitting any "]]>" into
+        // multiple adjacent CDATA sections while preserving exact content.
+        safeData = safeData.replace("]]>", "]]]]><![CDATA[>");
+        _buffer.append("<![CDATA[").append(safeData).append("]]>");
     }
 
     /**


### PR DESCRIPTION
Potential fix for [https://github.com/infonl/webdav-servlet/security/code-scanning/18](https://github.com/infonl/webdav-servlet/security/code-scanning/18)

General fix: ensure untrusted data written into XML is contextually encoded for its output context. For CDATA, the key rule is to prevent raw `]]>` from appearing inside content.

Best single fix with minimal functional impact: keep CDATA output, but make it safe by splitting any `]]>` sequence into adjacent CDATA sections (`]]]]><![CDATA[>`), which preserves the original text exactly while preventing CDATA breakout. Implement this centrally in `src/main/java/nl/info/webdav/fromcatalina/XMLWriter.java` inside `writeData(String data)`. Also handle `null` safely as empty string.

This addresses both variants because all tainted flows in the report reach the same sink path through `XMLWriter` buffering and `sendData()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
