### PR TITLE
chore: add unit test coverage

### DIFF
--- a/src/test/java/nl/info/webdav/WebDavServletBeanTest.java
+++ b/src/test/java/nl/info/webdav/WebDavServletBeanTest.java
@@ -7,9 +7,9 @@ package nl.info.webdav;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.Principal;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletException;
@@ -257,20 +257,37 @@ public class WebDavServletBeanTest extends MockTest {
 
     @Test
     public void testServiceWithUnconsumedInputStreamDrainsBytes() throws Exception {
-        AtomicInteger availableCallCount = new AtomicInteger(0);
         ServletInputStream stream = new ServletInputStream() {
+            private final ByteArrayInputStream bais = new ByteArrayInputStream(new byte[]{1, 2, 3, 4, 5});
+
             @Override
-            public boolean isFinished() { return false; }
+            public boolean isFinished() {
+                return bais.available() == 0;
+            }
+
             @Override
-            public boolean isReady() { return true; }
+            public boolean isReady() {
+                return true;
+            }
+
             @Override
-            public void setReadListener(ReadListener readListener) {}
+            public void setReadListener(ReadListener readListener) {
+            }
+
             @Override
-            public int read() { return -1; }
+            public int read() {
+                return bais.read();
+            }
+
             @Override
-            public int available() { return availableCallCount.getAndIncrement() == 0 ? 5 : 0; }
+            public int available() {
+                return bais.available();
+            }
+
             @Override
-            public long skip(long n) { return n; }
+            public long skip(long n) {
+                return bais.skip(n);
+            }
         };
 
         _mockery.checking(new Expectations() {
@@ -309,14 +326,31 @@ public class WebDavServletBeanTest extends MockTest {
     @Test
     public void testServiceContentLengthNonZeroButStreamFinishedSkipsDrain() throws Exception {
         ServletInputStream finishedStream = new ServletInputStream() {
+            private final ByteArrayInputStream bais = new ByteArrayInputStream(new byte[0]);
+
             @Override
-            public boolean isFinished() { return true; }
+            public boolean isFinished() {
+                return bais.available() == 0;
+            }
+
             @Override
-            public boolean isReady() { return true; }
+            public boolean isReady() {
+                return true;
+            }
+
             @Override
-            public void setReadListener(ReadListener readListener) {}
+            public void setReadListener(ReadListener readListener) {
+            }
+
             @Override
-            public int read() { return -1; }
+            public int read() {
+                return bais.read();
+            }
+
+            @Override
+            public int available() {
+                return bais.available();
+            }
         };
 
         _mockery.checking(new Expectations() {

--- a/src/test/java/nl/info/webdav/WebDavServletBeanTest.java
+++ b/src/test/java/nl/info/webdav/WebDavServletBeanTest.java
@@ -4,11 +4,16 @@
  */
 package nl.info.webdav;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
+import java.security.Principal;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -248,6 +253,222 @@ public class WebDavServletBeanTest extends MockTest {
 
         new TestBean(mockStore, mockExecutor).callService(mockReq, mockRes);
         _mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void testServiceWithUnconsumedInputStreamDrainsBytes() throws Exception {
+        AtomicInteger availableCallCount = new AtomicInteger(0);
+        ServletInputStream stream = new ServletInputStream() {
+            @Override
+            public boolean isFinished() { return false; }
+            @Override
+            public boolean isReady() { return true; }
+            @Override
+            public void setReadListener(ReadListener readListener) {}
+            @Override
+            public int read() { return -1; }
+            @Override
+            public int available() { return availableCallCount.getAndIncrement() == 0 ? 5 : 0; }
+            @Override
+            public long skip(long n) { return n; }
+        };
+
+        _mockery.checking(new Expectations() {
+            {
+                oneOf(mockReq).getMethod();
+                will(returnValue("GET"));
+
+                oneOf(mockReq).getUserPrincipal();
+                will(returnValue(null));
+
+                oneOf(mockStore).begin(null);
+                will(returnValue(mockTransaction));
+
+                oneOf(mockStore).checkAuthentication(mockTransaction);
+
+                oneOf(mockRes).setStatus(WebdavStatus.SC_OK);
+
+                oneOf(mockExecutor).execute(mockTransaction, mockReq, mockRes);
+
+                oneOf(mockStore).commit(mockTransaction);
+
+                oneOf(mockReq).getContentLength();
+                will(returnValue(100));
+
+                exactly(4).of(mockReq).getInputStream();
+                will(returnValue(stream));
+
+                never(mockStore).rollback(mockTransaction);
+            }
+        });
+
+        new TestBean(mockStore, mockExecutor).callService(mockReq, mockRes);
+        _mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void testServiceContentLengthNonZeroButStreamFinishedSkipsDrain() throws Exception {
+        ServletInputStream finishedStream = new ServletInputStream() {
+            @Override
+            public boolean isFinished() { return true; }
+            @Override
+            public boolean isReady() { return true; }
+            @Override
+            public void setReadListener(ReadListener readListener) {}
+            @Override
+            public int read() { return -1; }
+        };
+
+        _mockery.checking(new Expectations() {
+            {
+                oneOf(mockReq).getMethod();
+                will(returnValue("GET"));
+
+                oneOf(mockReq).getUserPrincipal();
+                will(returnValue(null));
+
+                oneOf(mockStore).begin(null);
+                will(returnValue(mockTransaction));
+
+                oneOf(mockStore).checkAuthentication(mockTransaction);
+
+                oneOf(mockRes).setStatus(WebdavStatus.SC_OK);
+
+                oneOf(mockExecutor).execute(mockTransaction, mockReq, mockRes);
+
+                oneOf(mockStore).commit(mockTransaction);
+
+                oneOf(mockReq).getContentLength();
+                will(returnValue(100));
+
+                oneOf(mockReq).getInputStream();
+                will(returnValue(finishedStream));
+
+                never(mockStore).rollback(mockTransaction);
+            }
+        });
+
+        new TestBean(mockStore, mockExecutor).callService(mockReq, mockRes);
+        _mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void testServiceIOExceptionAlreadyCommittedSkipsSendError() throws Exception {
+        _mockery.checking(new Expectations() {
+            {
+                oneOf(mockReq).getMethod();
+                will(returnValue("GET"));
+
+                oneOf(mockReq).getUserPrincipal();
+                will(returnValue(null));
+
+                oneOf(mockStore).begin(null);
+                will(returnValue(mockTransaction));
+
+                oneOf(mockStore).checkAuthentication(mockTransaction);
+
+                oneOf(mockRes).setStatus(WebdavStatus.SC_OK);
+
+                oneOf(mockExecutor).execute(mockTransaction, mockReq, mockRes);
+                will(throwException(new IOException("disk error")));
+
+                oneOf(mockRes).isCommitted();
+                will(returnValue(true));
+
+                never(mockRes).sendError(with(any(Integer.class)));
+
+                // IOException handler calls rollback, then finally block calls it again
+                // because needRollback is still true (the ServletException re-throw
+                // is caught by the outer catch(Exception) block)
+                exactly(2).of(mockStore).rollback(mockTransaction);
+            }
+        });
+
+        assertThrows(
+                ServletException.class,
+                () -> new TestBean(mockStore, mockExecutor).callService(mockReq, mockRes)
+        );
+        _mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void testServiceUnauthenticatedAlreadyCommittedSkipsSendError() throws Exception {
+        _mockery.checking(new Expectations() {
+            {
+                oneOf(mockReq).getMethod();
+                will(returnValue("GET"));
+
+                oneOf(mockReq).getUserPrincipal();
+                will(returnValue(null));
+
+                oneOf(mockStore).begin(null);
+                will(returnValue(mockTransaction));
+
+                oneOf(mockStore).checkAuthentication(mockTransaction);
+                will(throwException(new UnauthenticatedException()));
+
+                oneOf(mockRes).isCommitted();
+                will(returnValue(true));
+
+                never(mockRes).sendError(with(any(Integer.class)));
+
+                oneOf(mockStore).rollback(mockTransaction);
+            }
+        });
+
+        new TestBean(mockStore, mockExecutor).callService(mockReq, mockRes);
+        _mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void testServicePassesPrincipalToStoreBegin() throws Exception {
+        Principal principal = _mockery.mock(Principal.class);
+
+        _mockery.checking(new Expectations() {
+            {
+                oneOf(mockReq).getMethod();
+                will(returnValue("GET"));
+
+                oneOf(mockReq).getUserPrincipal();
+                will(returnValue(principal));
+
+                oneOf(mockStore).begin(principal);
+                will(returnValue(mockTransaction));
+
+                oneOf(mockStore).checkAuthentication(mockTransaction);
+
+                oneOf(mockRes).setStatus(WebdavStatus.SC_OK);
+
+                oneOf(mockExecutor).execute(mockTransaction, mockReq, mockRes);
+
+                oneOf(mockStore).commit(mockTransaction);
+
+                oneOf(mockReq).getContentLength();
+                will(returnValue(0));
+
+                never(mockStore).rollback(mockTransaction);
+            }
+        });
+
+        new TestBean(mockStore, mockExecutor).callService(mockReq, mockRes);
+        _mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void testDestroyCallsStoreDestroy() {
+        _mockery.checking(new Expectations() {
+            {
+                oneOf(mockStore).destroy();
+            }
+        });
+
+        new TestBean(mockStore, mockExecutor).destroy();
+        _mockery.assertIsSatisfied();
+    }
+
+    @Test
+    public void testDestroyWithNullStoreDoesNotThrow() {
+        assertDoesNotThrow(() -> new WebDavServletBean().destroy());
     }
 
     @Test


### PR DESCRIPTION
Add unit tests for various WebDavServletBean scenarios including input stream handling, exception cases, and principal usage.

Solves PZ-11179