### PR TITLE
ci(workflows): add least-privilege permissions to conventional commits check

### DIFF
--- a/.github/workflows/check-for-conventional-commits.yml
+++ b/.github/workflows/check-for-conventional-commits.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   check-for-conventional-commits:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: check-for-cc
         id: check-for-cc


### PR DESCRIPTION
## Summary
- Added `permissions` block to the `check-for-conventional-commits` job with `contents: read` and `pull-requests: read`
- Follows principle of least privilege — the action only reads PR title and commit messages, no write access needed


Solves PZ-11404